### PR TITLE
Object Oriented Scraper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,10 +32,6 @@ Style/DefWithParentheses:
   Enabled: false
 Style/FrozenStringLiteralComment:
   EnforcedStyle: never
-Style/GlobalVars:
-  AllowedVariables:
-    - $verbose
-
 
 Layout/HashAlignment:
   EnforcedColonStyle: key

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,10 @@ Style/DefWithParentheses:
   Enabled: false
 Style/FrozenStringLiteralComment:
   EnforcedStyle: never
+Style/GlobalVars:
+  AllowedVariables:
+    - $verbose
+
 
 Layout/HashAlignment:
   EnforcedColonStyle: key

--- a/bin/main.rb
+++ b/bin/main.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require_relative '../lib/argparser'
-require_relative '../lib/http'
+require_relative '../lib/provider'
 
 options_parser = GitHubLogManOptparser.new
 begin
@@ -16,7 +16,7 @@ end
 verbose = options.verbose.freeze
 url = options.url.freeze
 
-MyUtils.pinfo "URL to request: #{url}" if verbose
+MyUtils.pinfo "User provided URL: #{url}" if verbose
 
 begin
   StrictHTTP.validate_provider(url)
@@ -43,6 +43,7 @@ MyUtils.pinfo 'Got response from server, ready to parse' if verbose
 
 document = Nokogiri::HTML(http_object.to_s)
 
+ProviderFactory.new.build(url)
 puts "PR Title => #{document.css('.gh-header-title').css('span').first.children.text.strip}"
 puts "PR ID => #{document.css('.gh-header-title').css('span').last.children.text.strip}"
 puts "PR Status => #{document.css('.gh-header-meta').css('span').first.text.strip}"

--- a/bin/main.rb
+++ b/bin/main.rb
@@ -13,45 +13,8 @@ rescue OptionParser::ParseError => e
     PARSER_ECODE
   )
 end
-verbose = options.verbose.freeze
+$verbose = options.verbose.freeze
 url = options.url.freeze
 
-MyUtils.pinfo "User provided URL: #{url}" if verbose
-
-begin
-  StrictHTTP.validate_provider(url)
-rescue StrictHTTP::NoProvierError => e
-  MyUtils.exit_on_exception(
-    e,
-    'Only a small set of providers and changelogs is supported.',
-    PROVIDER_ECODE
-  )
-end
-
-begin
-  http_object = StrictHTTP.strict_get(url, 3)
-  status = http_object.status.code
-  MyUtils.pinfo "HTTP Request status code: #{status}" if verbose
-rescue HTTP::ConnectionError, HTTP::TimeoutError => e
-  MyUtils.exit_on_exception(
-    e,
-    'Plese check that your connection is up, working, and that the provided URL is correct.',
-    HTTP_ECODE
-  )
-end
-MyUtils.pinfo 'Got response from server, ready to parse' if verbose
-
-document = Nokogiri::HTML(http_object.to_s)
-
+MyUtils.pinfo "User provided URL: #{url}" if $verbose
 ProviderFactory.new.build(url)
-puts "PR Title => #{document.css('.gh-header-title').css('span').first.children.text.strip}"
-puts "PR ID => #{document.css('.gh-header-title').css('span').last.children.text.strip}"
-puts "PR Status => #{document.css('.gh-header-meta').css('span').first.text.strip}"
-puts "PR Base => #{document.css('.commit-ref').css('.css-truncate-target').first.children.text.strip.split("\n").first}"
-puts "PR Dest => #{document.css('.commit-ref').css('.css-truncate-target').last.children.text.strip.split("\n").first}"
-puts "PR Author => #{document.css('.timeline-comment-header-text').css('.author').first.text}"
-puts "PR T => #{document.css('.timeline-comment-header-text').css('relative-time').first.attributes['datetime'].value}"
-document.css('.js-commit-group-commits').css('.pr-1').css('code').each do |link|
-  puts "Commit Title => #{link.css('a').first.attributes['title'].value.strip.split("\n").first}"
-  puts "Commit Hash => #{link.css('a').first.attributes['href'].value.split('/').last}"
-end

--- a/bin/main.rb
+++ b/bin/main.rb
@@ -13,8 +13,6 @@ rescue OptionParser::ParseError => e
     PARSER_ECODE
   )
 end
-$verbose = options.verbose.freeze
-url = options.url.freeze
+MyUtils.verbose if options.verbose
 
-MyUtils.pinfo "User provided URL: #{url}" if $verbose
-ProviderFactory.new.build(url)
+ProviderFactory.new.build(options.url)

--- a/lib/argparser.rb
+++ b/lib/argparser.rb
@@ -3,8 +3,7 @@
 OptionParser.accept(URI) do |url|
   uri = URI.parse(url) if url
   unless uri.is_a?(URI::HTTP)
-    raise OptionParser::InvalidArgument,
-          'Invalid URL provied, try providing a URL like https://github.com/...'
+    raise OptionParser::InvalidArgument, 'Invalid URL provied, try providing a URL like https://github.com/...'
   end
 
   uri
@@ -28,15 +27,14 @@ class GitHubLogManOptparser
     end
 
     def define_options(parser)
-      parser.banner =
-        "\e[1m
+      parser.banner = "\e[1m
 Usage: #{parser.program_name} [options] -u URL
 Usage: #{parser.program_name} [options] --url URL\e[0m"
       parser.separator "Options can be 'long' when using the double minus or 'short' when using a single minus."
       parser.separator 'Except for the URL, all options are optional.'
       parser.separator nil
       parser.separator "Use \e[4mControl+C\e[0m in the terminal to exit the full-screen view."
-      parser.separator 'Use the shell redirection to write out the text-plain view into a file.'
+      parser.separator 'Use the shell redirection to write out the text-plain view or pipe it to other tools.'
       parser.separator nil
       option_verbose(parser)
       option_uri(parser)

--- a/lib/blessings.rb
+++ b/lib/blessings.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-# Brief description: Blessings is a Ruby module inspired in "curses"
 module Blessings
   def self.insert_newline(lines)
     lines.times do

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+class MergeRequest
+  def initialize
+    @title
+  end
+end
+
+class Commit
+  def initialize
+    @title
+  end
+end

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require_relative '../lib/utilities'
+require_relative 'utilities'
 
 module StrictHTTP
   include HTTP

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -5,6 +5,7 @@ require_relative 'utilities'
 module StrictHTTP
   include HTTP
   def self.strict_get(url, tout = 10)
+    MyUtils.pinfo "Starting HTTP request to '#{url}' with timeout #{tout}..."
     http_response = HTTP.timeout(tout).follow.get(url)
     status = http_response.status.code
     success = http_response.status.success?

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -4,29 +4,7 @@ require_relative 'utilities'
 
 module StrictHTTP
   include HTTP
-
-  PROVIDERS = ['github.com'].freeze
-  CHANGELOGS = ['pull'].freeze
-
-  class NoProvierError < StandardError; end
-
-  def self.validate_provider(url)
-    string_url = url.to_s
-    test = proc do |accumulator, element|
-      accumulator |= true if string_url.include?(element)
-      accumulator
-    end
-    valid_provider = PROVIDERS.inject(false, &test)
-    valid_changelog = CHANGELOGS.inject(false, &test)
-
-    list = MyUtils.array_to_list(PROVIDERS)
-    raise NoProvierError, "The URL is not from a supported provider, supported providers: #{list}" unless valid_provider
-
-    list = MyUtils.array_to_list(CHANGELOGS)
-    raise NoProvierError, "The URL has no supported changelog, supported changelogs: #{list}" unless valid_changelog
-  end
-
-  def self.strict_get(url, tout)
+  def self.strict_get(url, tout = 10)
     http_response = HTTP.timeout(tout).follow.get(url)
     status = http_response.status.code
     success = http_response.status.success?

--- a/lib/provider.rb
+++ b/lib/provider.rb
@@ -3,7 +3,7 @@
 require_relative 'git'
 require_relative 'http'
 
-class Provider
+module Provider
   attr_reader :valid
 
   def initialize(*)
@@ -64,7 +64,7 @@ class ProviderFactory
     @providers.each do |provider|
       MyUtils.pinfo "Checking if provider '#{provider}' can handle the URL..." if $verbose
       provider_built = provider.new(url)
-      return provider_built if provider_built.valid
+      return provider_built if provider_built.valid and provider_built.is_a?(Provider)
 
       MyUtils.pinfo "Provider '#{provider}' can not handle the URL" if $verbose
     end

--- a/lib/provider.rb
+++ b/lib/provider.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require_relative 'providers'
+
+class NoProvierError < StandardError
+end
+
+class ProviderFactory
+  def initialize
+    @providers = []
+    @providers << GitHub
+  end
+
+  def build(url)
+    @providers.each do |provider|
+      provider_built = provider.new(url)
+      return new_provider if provider_built.valid
+    end
+    raise NoProvierError, 'The given URL does not match any know provider'
+  end
+end

--- a/lib/provider.rb
+++ b/lib/provider.rb
@@ -1,11 +1,60 @@
 #!/usr/bin/env ruby
 
-require_relative 'providers'
+require_relative 'git'
+require_relative 'http'
 
-class NoProvierError < StandardError
+class Provider
+  attr_reader :valid
+
+  def initialize(*)
+    @supported = {}
+  end
+
+  private
+
+  def url_validator(url)
+    provider = self.class
+    @supported.each do |key, val|
+      break unless url.host == @host
+
+      MyUtils.pinfo "#{provider}: Checking if changelog type '#{key}' supports this URL..." if $verbose
+      next unless url.request_uri.include? key.to_s
+
+      MyUtils.pinfo "#{provider}: Changelog type '#{key}' support this URL" if $verbose
+      @valid = true
+      @changelog_type = val
+      break
+    end
+    @valid
+  end
+
+  def get_html(url)
+    MyUtils.pinfo 'Downloading the webpage...' if $verbose
+    @dom = Nokogiri::HTML(StrictHTTP.strict_get(url).to_s)
+    MyUtils.pinfo 'Webpage downloaded successfully' if $verbose
+  end
+
+  def scrape(); end
+
+  def first_line(line)
+    line.strip.split("\n").first.strip
+  end
+
+  def build_provider(url)
+    url_validated = url_validator(url)
+    get_html(url) if url_validated
+    MyUtils.pinfo 'Executing the scraper...' if $verbose
+    scraped = scrape if url_validated
+    MyUtils.pinfo "Scraping #{scraped ? 'succeeded' : 'failed'}" if $verbose
+  end
 end
 
+require_relative 'providers'
+
+class NoProviderError < StandardError; end
+
 class ProviderFactory
+  # Add new providers here, just by pushing the class into the @providers array. Do not modify anything else.
   def initialize
     @providers = []
     @providers << GitHub
@@ -19,6 +68,6 @@ class ProviderFactory
 
       MyUtils.pinfo "Provider '#{provider}' can not handle the URL" if $verbose
     end
-    raise NoProvierError, 'The given URL is not supported by any provider'
+    raise NoProviderError, 'The given URL is not supported by any provider'
   end
 end

--- a/lib/provider.rb
+++ b/lib/provider.rb
@@ -47,16 +47,19 @@ module Provider
     get_html(url) if @valid
     MyUtils.pinfo "Scraping a #{self.class} #{@changelog_type}..." if @valid
     scraped = scrape if @valid
+    @dom = nil
     MyUtils.pinfo "Scraping #{scraped ? 'succeeded' : 'failed'}"
   end
 end
 
-require_relative 'providers'
-
 class NoProviderError < StandardError; end
 
+class ScraperError < StandardError; end
+
+require_relative 'providers'
+
 class ProviderFactory
-  # Add new providers here, just by pushing the class into the @providers array. Do not modify anything else.
+  # Add new providers here by pushing the class into the @providers array. Do not modify anything else.
   def initialize
     @providers = []
     @providers << GitHub

--- a/lib/provider.rb
+++ b/lib/provider.rb
@@ -62,7 +62,7 @@ class ProviderFactory
   # Add new providers here by pushing the class into the @providers array. Do not modify anything else.
   def initialize
     @providers = []
-    @providers << GitHub
+    @providers << GitHubProvider
   end
 
   def build(url)

--- a/lib/provider.rb
+++ b/lib/provider.rb
@@ -17,10 +17,10 @@ module Provider
     @supported.each do |key, val|
       break unless url.host == @host
 
-      MyUtils.pinfo "#{provider}: Checking if changelog type '#{key}' supports this URL..." if $verbose
+      MyUtils.pinfo "#{provider}: Checking if changelog type '#{key}' supports this URL..."
       next unless url.request_uri.include? key.to_s
 
-      MyUtils.pinfo "#{provider}: Changelog type '#{key}' support this URL" if $verbose
+      MyUtils.pinfo "#{provider}: Changelog type '#{key}' support this URL"
       @valid = true
       @changelog_type = val
       break
@@ -29,23 +29,25 @@ module Provider
   end
 
   def get_html(url)
-    MyUtils.pinfo 'Downloading the webpage...' if $verbose
+    MyUtils.pinfo 'Downloading the webpage...'
     @dom = Nokogiri::HTML(StrictHTTP.strict_get(url).to_s)
-    MyUtils.pinfo 'Webpage downloaded successfully' if $verbose
+    MyUtils.pinfo 'Webpage downloaded successfully'
   end
 
-  def scrape(); end
+  def scrape()
+    raise NotImplementedError, "Please create a provider than inherits from #{Provider} and implement `scrape`."
+  end
 
   def first_line(line)
-    line.strip.split("\n").first.strip
+    line.strip.split("\n").first
   end
 
   def build_provider(url)
-    url_validated = url_validator(url)
-    get_html(url) if url_validated
-    MyUtils.pinfo 'Executing the scraper...' if $verbose
-    scraped = scrape if url_validated
-    MyUtils.pinfo "Scraping #{scraped ? 'succeeded' : 'failed'}" if $verbose
+    url_validator(url)
+    get_html(url) if @valid
+    MyUtils.pinfo "Scraping a #{self.class} #{@changelog_type}..." if @valid
+    scraped = scrape if @valid
+    MyUtils.pinfo "Scraping #{scraped ? 'succeeded' : 'failed'}"
   end
 end
 
@@ -62,11 +64,11 @@ class ProviderFactory
 
   def build(url)
     @providers.each do |provider|
-      MyUtils.pinfo "Checking if provider '#{provider}' can handle the URL..." if $verbose
+      MyUtils.pinfo "Checking if provider '#{provider}' can handle the URL..."
       provider_built = provider.new(url)
       return provider_built if provider_built.valid and provider_built.is_a?(Provider)
 
-      MyUtils.pinfo "Provider '#{provider}' can not handle the URL" if $verbose
+      MyUtils.pinfo "Provider '#{provider}' can not handle the URL"
     end
     raise NoProviderError, 'The given URL is not supported by any provider'
   end

--- a/lib/provider.rb
+++ b/lib/provider.rb
@@ -13,9 +13,12 @@ class ProviderFactory
 
   def build(url)
     @providers.each do |provider|
+      MyUtils.pinfo "Checking if provider '#{provider}' can handle the URL..." if $verbose
       provider_built = provider.new(url)
-      return new_provider if provider_built.valid
+      return provider_built if provider_built.valid
+
+      MyUtils.pinfo "Provider '#{provider}' can not handle the URL" if $verbose
     end
-    raise NoProvierError, 'The given URL does not match any know provider'
+    raise NoProvierError, 'The given URL is not supported by any provider'
   end
 end

--- a/lib/providers.rb
+++ b/lib/providers.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+
+require_relative 'http'
+require_relative 'git'
+
+class Provider
+  attr_reader :host, :valid
+
+  def initialize(*)
+    @host = 'nodomain.com'
+    @name = 'Generic Provider'
+    @changelog = MergeRequest
+    @supported = {}
+    @valid = false
+  end
+
+  private
+
+  def url_validator(url)
+    @supported.each do |key, val|
+      break if url.host == @host
+
+      request = url.request_uri
+      next unless request.include? key.to_s
+
+      @valid = true
+      @changelog = val
+      break
+    end
+  end
+
+  def get_html(url); end
+end
+
+# - if you want to extend the functionality, add more providers here and don't forget to add them to the factory too -
+
+class GitHub < Provider
+  def initialize(url)
+    super
+    @host = 'github.com'
+    @name = 'GitHub'
+    @supported[:pull] = MergeRequest
+    get_html(url) if url_validator(url)
+  end
+end

--- a/lib/providers.rb
+++ b/lib/providers.rb
@@ -2,7 +2,8 @@
 
 # - if you want to extend the functionality, add more providers here and don't forget to also add them to the factory -
 
-class GitHub < Provider
+class GitHub
+  include Provider
   def initialize(url)
     super
     @host = 'github.com'

--- a/lib/providers.rb
+++ b/lib/providers.rb
@@ -17,16 +17,20 @@ class Provider
   private
 
   def url_validator(url)
+    provider = self.class
     @supported.each do |key, val|
-      break if url.host == @host
+      break unless url.host == @host
 
+      MyUtils.pinfo "#{provider}: Checking if changelog type '#{key}' supports this URL..." if $verbose
       request = url.request_uri
       next unless request.include? key.to_s
 
+      MyUtils.pinfo "#{provider}: Changelog type '#{key}' support this URL" if $verbose
       @valid = true
       @changelog = val
       break
     end
+    @valid
   end
 
   def get_html(url); end

--- a/lib/providers.rb
+++ b/lib/providers.rb
@@ -31,11 +31,13 @@ class GitHub
 
   def scrape()
     @changelog = @changelog_type.new
+    scraped = true
     case @changelog
     when MergeRequest
       scrape_pull_request
     else
-      false
+      scraped = false
     end
+    scraped
   end
 end

--- a/lib/providers.rb
+++ b/lib/providers.rb
@@ -2,7 +2,7 @@
 
 # - if you want to extend the functionality, add more providers here and don't forget to also add them to the factory -
 
-class GitHub
+class GitHubProvider
   include Provider
   def initialize(url)
     super

--- a/lib/utilities.rb
+++ b/lib/utilities.rb
@@ -3,12 +3,14 @@
 require_relative 'blessings'
 
 module MyUtils
-  private_class_method def self.custom_p(intro, msg)
-    if msg.nil?
-      warn msg
-    else
-      warn("#{intro}#{msg}")
-    end
+  attr_reader :verbose
+
+  def initialize
+    @verbose = false
+  end
+
+  def self.verbose
+    @verbose = true
   end
 
   def self.perr(arg)
@@ -30,6 +32,8 @@ module MyUtils
   end
 
   def self.pinfo(arg)
+    return unless @verbose
+
     Blessings.blue
     custom_p('INFO: ', arg)
     Blessings.reset_color
@@ -44,5 +48,13 @@ module MyUtils
     perr nil
     perr message
     exit code
+  end
+
+  private_class_method def self.custom_p(intro, msg)
+    if msg.nil?
+      warn msg
+    else
+      warn("#{intro}#{msg}")
+    end
   end
 end

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -4,11 +4,9 @@ require_relative '../lib/http'
 
 RSpec.describe 'StrictHTTP' do
   let(:valid_but_error) { 'https://google.com/notfound' }
-  let(:no_provider) { 'https://google.com' }
   let(:valid_but_nx) { 'http://nx-domain.com' }
-  let(:good) { 'https://github.com' }
-  let(:perfect) { 'https://github.com/NoTengoBattery/GitHubLogMan/pull/1' }
   let(:timeout) { 'https://gi.com' }
+  let(:good) { 'https://github.com' }
   it 'rejects valid URLs that return HTTP error codes' do
     expect { StrictHTTP.strict_get(valid_but_error, 3) }.to raise_error(HTTP::ConnectionError)
   end
@@ -20,14 +18,5 @@ RSpec.describe 'StrictHTTP' do
   end
   it 'accepts valid HTTP URLs that return HTTP success codes' do
     expect { StrictHTTP.strict_get(good, 3) }.not_to raise_error
-  end
-  it 'rejects valid URLs that are not from a valid provider' do
-    expect { StrictHTTP.validate_provider(no_provider) }.to raise_error(StrictHTTP::NoProvierError)
-  end
-  it 'rejects valid URLs that do not have a valid changelog' do
-    expect { StrictHTTP.validate_provider(good) }.to raise_error(StrictHTTP::NoProvierError)
-  end
-  it 'accepts valid URLs that have a valid changelog and provider' do
-    expect { StrictHTTP.validate_provider(perfect) }.not_to raise_error
   end
 end

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -2,20 +2,40 @@
 
 require_relative '../lib/provider'
 
+OPENWRT_GITHUB = 'https://github.com/openwrt'.freeze
+OPENWRT_GITHUB_PR = "#{OPENWRT_GITHUB}/openwrt/pull/1".freeze
+
 RSpec.describe 'ProviderFactory' do
   let(:factory) { ProviderFactory.new }
   let(:no_provider) { URI.parse('https://www.google.com') }
   describe 'GitHubFactory' do
-    let(:github) { URI.parse('https://github.com/openwrt/openwrt/pull/1') }
-    let(:github_invalid) { URI.parse('https://github.com/openwrt') }
+    let(:github) { URI.parse(OPENWRT_GITHUB_PR) }
+    let(:github_invalid) { URI.parse(OPENWRT_GITHUB) }
     it 'returns a GitHub provider when a valid GitHub link is given' do
-      factory.build(github)
+      expect(factory.build(github)).to be_a(GitHub)
     end
     it 'throws an error when an invalid GitHub link is given' do
       expect { factory.build(github_invalid) }.to raise_error(NoProviderError)
     end
     it 'throws an error when a valid URL is given, but is not GitHub' do
       expect { factory.build(no_provider) }.to raise_error(NoProviderError)
+    end
+  end
+end
+
+RSpec.describe 'Provider' do
+  describe 'GitHub' do
+    let(:github) { URI.parse(OPENWRT_GITHUB_PR) }
+    let(:github_invalid) { URI.parse(OPENWRT_GITHUB) }
+    let(:github_provider) { GitHub.new(github) }
+    let(:github_provider_invalid) { GitHub.new(github_invalid) }
+    it 'scrapes a valid GitHub Pull Request' do
+      expect(github_provider).to be_a(GitHub)
+      expect(github_provider.valid).to be_truthy
+    end
+    it 'rejects a GitHub page that is not supported' do
+      expect(github_provider_invalid).to be_a(GitHub)
+      expect(github_provider_invalid.valid).to be_falsy
     end
   end
 end

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require_relative '../lib/provider'
+
+RSpec.describe 'ProviderFactory' do
+  let(:factory) { ProviderFactory.new }
+  let(:no_provider) { URI.parse('https://www.google.com') }
+  describe 'GitHubFactory' do
+    let(:github) { URI.parse('https://github.com/openwrt/openwrt/pull/1') }
+    let(:github_invalid) { URI.parse('https://github.com/openwrt') }
+    it 'returns a GitHub provider when a valid GitHub link is given' do
+      factory.build(github)
+    end
+    it 'throws an error when an invalid GitHub link is given' do
+      expect { factory.build(github_invalid) }.to raise_error(NoProviderError)
+    end
+    it 'throws an error when a valid URL is given, but is not GitHub' do
+      expect { factory.build(no_provider) }.to raise_error(NoProviderError)
+    end
+  end
+end

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'ProviderFactory' do
     let(:github) { URI.parse(OPENWRT_GITHUB_PR) }
     let(:github_invalid) { URI.parse(OPENWRT_GITHUB) }
     it 'returns a GitHub provider when a valid GitHub link is given' do
-      expect(factory.build(github)).to be_a(GitHub)
+      expect(factory.build(github)).to be_a(GitHubProvider)
     end
     it 'throws an error when an invalid GitHub link is given' do
       expect { factory.build(github_invalid) }.to raise_error(NoProviderError)
@@ -27,14 +27,14 @@ RSpec.describe 'Provider' do
   describe 'GitHub' do
     let(:github) { URI.parse(OPENWRT_GITHUB_PR) }
     let(:github_invalid) { URI.parse(OPENWRT_GITHUB) }
-    let(:github_provider) { GitHub.new(github) }
-    let(:github_provider_invalid) { GitHub.new(github_invalid) }
+    let(:github_provider) { GitHubProvider.new(github) }
+    let(:github_provider_invalid) { GitHubProvider.new(github_invalid) }
     it 'scrapes a valid GitHub Pull Request' do
-      expect(github_provider).to be_a(GitHub)
+      expect(github_provider).to be_a(GitHubProvider)
       expect(github_provider.valid).to be_truthy
     end
     it 'rejects a GitHub page that is not supported' do
-      expect(github_provider_invalid).to be_a(GitHub)
+      expect(github_provider_invalid).to be_a(GitHubProvider)
       expect(github_provider_invalid.valid).to be_falsy
     end
   end


### PR DESCRIPTION
# Object Oriented Scraper designed to be extensible

This will move all the code from `main.rb` into some modules and classes, such as Provider and GitHubProvider. Developers can add and implement more Providers, only caring about the scraping logic. The `ProviderFactory` will take care of selecting the correct scraper for the requested URL. The following changes will be merged.

- Implement a `ProviderFactory` factory
- Implement the core `Provider` superclass as a Ruby Module
- Implement a specific use case for GitHub into `GitHubProvider`

Any comments are welcome. If you have any problem with this code, discuss it in this pull request. For code in the master/main branch, please open a GitHub Issue [here](https://github.com/NoTengoBattery/GitHubLogMan/issues).