### PR TITLE
Git Model: classes to represent git objects

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,5 @@
+run="bundle exec ruby main.rb -u https://github.com/NoTengoBattery/GitHubLogMan/pull/1"
+language="ruby"
+
+[packager]
+ignoredPaths=[".bundle", ".git", ".github", "spec", "vendor"]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - "vendor/**/*"
   NewCops: enable
   DisplayCopNames: true
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.5
 
 Layout/LineLength:
   Max: 120

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - "vendor/**/*"
   NewCops: enable
   DisplayCopNames: true
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.6
 
 Layout/LineLength:
   Max: 120

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '>=2.7'
+ruby '>=2.5'
 
 gem 'curses', require: true
 gem 'http', require: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,10 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     curses (1.4.0)
-    date (3.1.0)
     diff-lcs (1.4.4)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     ffi (1.14.2)
-    ffi (1.14.2-java)
-    ffi (1.14.2-x64-mingw32)
-    ffi (1.14.2-x86-mingw32)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -33,18 +29,6 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogiri (1.11.1-java)
-      racc (~> 1.4)
-    nokogiri (1.11.1-x64-mingw32)
-      racc (~> 1.4)
-    nokogiri (1.11.1-x86-linux)
-      racc (~> 1.4)
-    nokogiri (1.11.1-x86-mingw32)
-      racc (~> 1.4)
-    nokogiri (1.11.1-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.11.1-x86_64-linux)
-      racc (~> 1.4)
     optparse (0.1.0)
     parallel (1.20.1)
     parser (3.0.0.0)
@@ -52,16 +36,11 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry (0.13.1-java)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-      spoon (~> 0.0)
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
     racc (1.5.2)
-    racc (1.5.2-java)
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.0.3)
@@ -91,29 +70,15 @@ GEM
     rubocop-ast (1.4.0)
       parser (>= 2.7.1.5)
     ruby-progressbar (1.11.0)
-    spoon (0.0.6)
-      ffi
     time (0.1.0)
-      date
     unf (0.1.4)
       unf_ext
-    unf (0.1.4-java)
     unf_ext (0.0.7.7)
     unicode-display_width (2.0.0)
     uri (0.10.1)
 
 PLATFORMS
-  java
   ruby
-  universal-java
-  universal-linux
-  universal-macruby
-  universal-mingw32
-  universal-mswin32
-  universal-unknown
-  x86-mswin32
-  x86_64-darwin
-  x86_64-darwin-19
 
 DEPENDENCIES
   curses
@@ -127,7 +92,7 @@ DEPENDENCIES
   uri
 
 RUBY VERSION
-   ruby 2.7
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/bin/main.rb
+++ b/bin/main.rb
@@ -3,16 +3,37 @@
 require_relative '../lib/argparser'
 require_relative '../lib/provider'
 
-options_parser = GitHubLogManOptparser.new
 begin
-  options = options_parser.parse(ARGV)
+  options = GitHubLogManOptparser.new.parse(ARGV)
 rescue OptionParser::ParseError => e
   MyUtils.exit_on_exception(
-    e,
-    'For more information about the usage of this script, run it with the -h flag.',
+    e, 'For more information about the usage of this script, run it with the -h flag.',
     PARSER_ECODE
   )
 end
-MyUtils.verbose if options.verbose
+MyUtils.verbose = options.verbose
 
-ProviderFactory.new.build(options.url)
+MyUtils.note('The program has started. Please wait while the request is completed...')
+MyUtils.note(nil)
+MyUtils.note('This process may take a while for large changelogs.')
+MyUtils.note('Enable the verbose mode to see the proccess as it runs.')
+MyUtils.note('For more information about the usage of this script, run it with the -h flag.')
+begin
+  ProviderFactory.new.build(options.url)
+rescue NoProviderError => e
+  MyUtils.exit_on_exception(
+    e, 'Run this scirpt with the verbose option to see all the available providers. For more help use the -h flag.',
+    PARSER_ECODE
+  )
+rescue HTTP::ConnectionError => e
+  MyUtils.exit_on_exception(
+    e, 'Provide a valid URL and ensure a stable internet connection.',
+    PARSER_ECODE
+  )
+rescue ScraperError => e
+  MyUtils.exit_on_exception(
+    e, "Please report this issue to the mantainer. Do not forget to provide the requested URL: #{options.url}",
+    PARSER_ECODE
+  )
+end
+MyUtils.note('All information was correctly retrieved from the internet')

--- a/environment.rb
+++ b/environment.rb
@@ -4,5 +4,5 @@ PARSER_ECODE = 1
 HTTP_ECODE = 2
 PROVIDER_ECODE = 3
 
-require 'bundler'
+require 'bundler/inline'
 Bundler.require(:default)

--- a/lib/argparser.rb
+++ b/lib/argparser.rb
@@ -3,20 +3,37 @@
 OptionParser.accept(URI) do |url|
   uri = URI.parse(url) if url
   unless uri.is_a?(URI::HTTP)
-    raise OptionParser::InvalidArgument, 'Invalid URL provied, try providing a URL like https://github.com/...'
+    raise(OptionParser::InvalidArgument, 'Invalid URL provided, try providing a URL like https://github.com/...')
   end
 
   uri
 end
 
 class GitHubLogManOptparser
+  attr_reader :parser, :options
+
   class ScriptOptions
     attr_reader :verbose, :url
 
-    def initialize
-      @verbose = false
-      @url = nil
+    def define_options(parser)
+      parser.banner = "\e[1m
+Usage: #{parser.program_name} [options] -u URL
+Usage: #{parser.program_name} [options] --url URL\e[0m"
+      parser.separator("Options can be 'long' when using the double minus or 'short' when using a single minus.")
+      parser.separator('Except for the URL, all options are optional.')
+      parser.separator(nil)
+      parser.separator("Use \e[4mControl+C\e[0m in the terminal to exit the full-screen view.")
+      parser.separator('Use the shell redirection to write out the text-plain view or pipe it to other tools.')
+      parser.separator(nil)
+      option_verbose(parser)
+      option_uri(parser)
+      parser.on_tail('-h', '--help', 'Show this message') do
+        puts(parser)
+        exit
+      end
     end
+
+    private
 
     def option_verbose(parser)
       parser.on('-v', '--[no-]verbose', 'Run this script with verbose output') { |value| @verbose = value }
@@ -25,24 +42,6 @@ class GitHubLogManOptparser
     def option_uri(parser)
       parser.on('-u', '--url URL', URI, 'The URL where the changelog is hosted') { |value| @url = value }
     end
-
-    def define_options(parser)
-      parser.banner = "\e[1m
-Usage: #{parser.program_name} [options] -u URL
-Usage: #{parser.program_name} [options] --url URL\e[0m"
-      parser.separator "Options can be 'long' when using the double minus or 'short' when using a single minus."
-      parser.separator 'Except for the URL, all options are optional.'
-      parser.separator nil
-      parser.separator "Use \e[4mControl+C\e[0m in the terminal to exit the full-screen view."
-      parser.separator 'Use the shell redirection to write out the text-plain view or pipe it to other tools.'
-      parser.separator nil
-      option_verbose(parser)
-      option_uri(parser)
-      parser.on_tail('-h', '--help', 'Show this message') do
-        puts parser
-        exit
-      end
-    end
   end
 
   def parse(args)
@@ -50,10 +49,8 @@ Usage: #{parser.program_name} [options] --url URL\e[0m"
     @args = OptionParser.new do |parser|
       @options.define_options(parser)
       parser.parse!(args)
-      raise OptionParser::MissingArgument, 'The URL parameter is required' if @options.url.nil?
+      raise(OptionParser::MissingArgument, 'The URL parameter is required') if @options.url.nil?
     end
     @options
   end
-
-  attr_reader :parser, :options
 end

--- a/lib/blessings.rb
+++ b/lib/blessings.rb
@@ -3,7 +3,7 @@
 module Blessings
   def self.insert_newline(lines)
     lines.times do
-      print "\n"
+      print("\n")
     end
   end
 
@@ -54,13 +54,13 @@ module Blessings
 
   def self.horizontal_bar(content, repetitions)
     repetitions.times do
-      print content
+      print(content)
     end
   end
 
   def self.vertical_bar(content, repetitions)
     repetitions.times do
-      print content
+      print(content)
       relative_move_to(-content.length, 1)
     end
     relative_move_to(content.length, -1)
@@ -68,7 +68,7 @@ module Blessings
 
   def self.relative_print_at(content, horizontal, vertical)
     relative_move_to(horizontal, vertical)
-    print content
+    print(content)
   end
 
   private_class_method def self.top_square_border(border, side_length)

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -1,13 +1,45 @@
 #!/usr/bin/env ruby
 
-class MergeRequest
-  def initialize
-    @title
+class GitMessage
+  attr_reader :time, :url
+  attr_accessor :subject, :id, :message, :author, :name
+
+  def initialize(name = 'Git Message')
+    @name = name
+  end
+
+  def url=(uri)
+    uri.is_a?(URI) ? (@url = uri) : raise(ArgumentError, "Expected an object of type #{URI}")
+  end
+
+  def time=(time)
+    case time
+    when Time
+      @time = time
+    when String, Numeric
+      @time = Time.parse(time)
+    else
+      raise(ArgumentError, "Expected a #{Time} object, a convertible #{String}, or a #{Numeric} value")
+    end
   end
 end
 
-class Commit
-  def initialize
-    @title
+class Commit < GitMessage
+  def initialize(name = 'Git Commit')
+    super
+  end
+end
+
+class MergeRequest < GitMessage
+  attr_reader :commits
+  attr_accessor :status, :target_branch, :base_branch
+
+  def initialize(name = 'Merge Request')
+    super
+    @commits = []
+  end
+
+  def commits=(commit)
+    commit.is_a?(Commit) ? (@commits << commit) : raise(ArgumentError, "Expected an object of type #{Commit}")
   end
 end

--- a/lib/http.rb
+++ b/lib/http.rb
@@ -5,12 +5,13 @@ require_relative 'utilities'
 module StrictHTTP
   include HTTP
   def self.strict_get(url, tout = 10)
-    MyUtils.pinfo "Starting HTTP request to '#{url}' with timeout #{tout}..."
+    MyUtils.pinfo("Starting HTTP request to '#{url}' with timeout #{tout}...")
     http_response = HTTP.timeout(tout).follow.get(url)
     status = http_response.status.code
     success = http_response.status.success?
-    raise HTTP::ConnectionError, "HTTP/HTTPS request failed: server status code #{status}" unless success
+    raise(HTTP::ConnectionError, "HTTP/HTTPS request failed: server status code #{status}") unless success
 
+    MyUtils.pinfo("Successful HTTP request to '#{url}'")
     http_response
   end
 end

--- a/lib/provider.rb
+++ b/lib/provider.rb
@@ -31,10 +31,7 @@ module Provider
         @changelog_type = val
         break
       end
-      unless @valid
-        raise(NoProviderHandlerError,
-              "The URL is a malformed #{@name} webpage, and #{@name} can not handle it")
-      end
+      raise(NoProviderHandlerError, "The URL is a malformed #{@name} webpage and can not be handled") unless @valid
     end
     @valid
   end

--- a/lib/provider.rb
+++ b/lib/provider.rb
@@ -68,13 +68,13 @@ module Provider
   end
 end
 
-require_relative 'providers'
+require_relative 'scrapers'
 
 # Add new providers here by pushing the class into the @providers array. Do not modify anything else.
 class ProviderFactory
   def initialize
     @providers = []
-    @providers << GitHubProvider
+    @providers << GitHubScraper
   end
 
   def build(url)

--- a/lib/providers.rb
+++ b/lib/providers.rb
@@ -1,13 +1,14 @@
 #!/usr/bin/env ruby
 
 # - if you want to extend the functionality, add more providers here and don't forget to also add them to the factory -
-# Because of how Nokogiri works, scrape methods may trigger Metric/AbcSize hint due to chained calls
+# - because of how `nokogiri` works, scrape methods may trigger Metric/AbcSize hint due to chained calls -
 
 class GitHubProvider
   include Provider
   def initialize(url)
     super
     @host = 'github.com'
+    @base_url = 'https://github.com'
     @name = 'GitHub'
     @supported[:pull] = MergeRequest
     build_provider(url)
@@ -15,17 +16,32 @@ class GitHubProvider
 
   private
 
-  def scrape_pull_request
-    puts "MR TITLE => #{@dom.css('.gh-header-title span').first.children.text}"
-    puts "MR ID => #{@dom.css('.gh-header-title span').last.children.text}"
-    puts "MR Status => #{@dom.css('.gh-header-meta span').first.text}"
-    puts "MR Base => #{@dom.css('.commit-ref a').first.attributes['title'].value}"
-    puts "MR Dest => #{@dom.css('.commit-ref a').last.attributes['title'].value}"
-    puts "MR Author => #{@dom.css('.timeline-comment-header-text .author').first.text}"
-    puts "PR Time => #{@dom.css('.timeline-comment-header-text relative-time').first.attributes['datetime'].value}"
-    @dom.css('.js-commit-group-commits .pr-1 code a.link-gray').each do |commit|
-      puts "\tCommit Title => #{first_line(commit.attributes['title'].value)}"
-      puts "\tCommit Hash => #{commit.attributes['href'].value.split('/').last}"
+  def scrape_pull_request # rubocop:disable Metric/AbcSize, Metrics/MethodLength
+    title = @dom.css('.gh-header-title span')
+    branches = @dom.css('.commit-ref a')
+    @changelog.subject = title.first.children.text.strip
+    @changelog.id = title.last.children.text.strip
+    @changelog.time = @dom.css('.timeline-comment-header-text relative-time').first.attributes['datetime'].value
+    @changelog.author = @dom.css('.timeline-comment-header-text .author').first.text.strip
+    @changelog.url = @req_url
+    @changelog.status = @dom.css('.gh-header-meta span').first.text.strip
+    @changelog.target_branch = branches.first.attributes['title'].value.strip
+    begin
+      @changelog.base_branch = branches.last.attributes['title'].value.strip
+    rescue NoMethodError
+      @changelog.base_branch = 'Unknown repository'
+    end
+    @dom.css('.js-commit-group-commits .pr-1 code a.link-gray').each do |commit_html|
+      commit = Commit.new
+      url = URI.parse("#{@base_url}#{commit_html.attributes['href'].value}")
+      commit_dom = Nokogiri::HTML(StrictHTTP.strict_get(url).to_s)
+      commit.subject = commit_dom.css('.commit-title').first.children.text.strip
+      commit.id = commit_dom.css('.sha').first.children.text.strip
+      commit.time = commit_dom.css('relative-time').last.attributes['datetime'].value
+      commit.message = commit_dom.css('.commit-desc pre').first.children.text.strip
+      commit.author = commit_dom.css('.commit-author').first.children.text.strip
+      commit.url = url
+      @changelog.commits = commit
     end
   end
 
@@ -34,6 +50,7 @@ class GitHubProvider
     scraped = true
     case @changelog
     when MergeRequest
+      @changelog.name = 'Pull Request'
       scrape_pull_request
     else
       scraped = false

--- a/lib/utilities.rb
+++ b/lib/utilities.rb
@@ -3,14 +3,12 @@
 require_relative 'blessings'
 
 module MyUtils
-  attr_reader :verbose
-
-  def initialize
+  def self.initialize
     @verbose = false
   end
 
-  def self.verbose
-    @verbose = true
+  def self.verbose=(val)
+    @verbose = val
   end
 
   def self.perr(arg)
@@ -39,20 +37,24 @@ module MyUtils
     Blessings.reset_color
   end
 
+  def self.note(arg)
+    custom_p('NOTE: ', arg)
+  end
+
   def self.array_to_list(array)
     array.reduce { |c, v| "#{c}, #{v}" }
   end
 
   def self.exit_on_exception(exeption, message, code)
-    perr exeption
-    perr nil
-    perr message
-    exit code
+    perr("#{exeption.class}: #{exeption}")
+    perr(nil)
+    perr(message)
+    exit(code)
   end
 
   private_class_method def self.custom_p(intro, msg)
     if msg.nil?
-      warn msg
+      warn(msg)
     else
       warn("#{intro}#{msg}")
     end

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -4,6 +4,7 @@ require_relative '../lib/provider'
 
 OPENWRT_GITHUB = 'https://github.com/openwrt'.freeze
 OPENWRT_GITHUB_PR = "#{OPENWRT_GITHUB}/openwrt/pull/1".freeze
+FAKE_GITHUB_PR = 'https://github.com/pull'.freeze
 
 RSpec.describe 'ProviderFactory' do
   let(:factory) { ProviderFactory.new }
@@ -25,17 +26,19 @@ end
 
 RSpec.describe 'Provider' do
   describe 'GitHub' do
+    let(:fake) { URI.parse(FAKE_GITHUB_PR) }
     let(:github) { URI.parse(OPENWRT_GITHUB_PR) }
     let(:github_invalid) { URI.parse(OPENWRT_GITHUB) }
     let(:github_provider) { GitHubProvider.new(github) }
-    let(:github_provider_invalid) { GitHubProvider.new(github_invalid) }
     it 'scrapes a valid GitHub Pull Request' do
       expect(github_provider).to be_a(GitHubProvider)
       expect(github_provider.valid).to be_truthy
     end
     it 'rejects a GitHub page that is not supported' do
-      expect(github_provider_invalid).to be_a(GitHubProvider)
-      expect(github_provider_invalid.valid).to be_falsy
+      expect { GitHubProvider.new(github_invalid) }.to raise_error(NoProviderHandlerError)
+    end
+    it 'rejects a GitHub page that is a fake pull request' do
+      expect { GitHubProvider.new(fake) }.to raise_error(ScraperError)
     end
   end
 end


### PR DESCRIPTION
# Git Model: modeling git messages such as Merge Requests and Commits

After implementing the scraper's core functionality, the next logical step is to store the extracted information. The scraper code will generate all the `GitMessage` objects with the extracted information. These objects later will be used to print the view by using `Printer`s. This pull request will:

- Model git messages as objects
- Prepare the code for repl.it
- Store the information from the `Provider` into implementations of `GitMessage`
- Add meaningful explanations for errors in `main.rb`
- Create a test suite for the added code

Any comments are welcome. If you have any problem with this code, discuss it in this pull request. For code in the master/main branch, please open a GitHub Issue [here](https://github.com/NoTengoBattery/GitHubLogMan/issues).